### PR TITLE
Used shared_task decorator for better compatibility

### DIFF
--- a/django_cached_field/tasks.py
+++ b/django_cached_field/tasks.py
@@ -1,4 +1,4 @@
-from celery import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.db.models import get_model
 import re
@@ -7,8 +7,7 @@ import re
 logger = get_task_logger(__name__)
 recalc_needed_re = re.compile("(.*)_recalculation_needed$")
 
-
-@task
+@shared_task
 def offload_cache_recalculation(app, model, obj_id, **kwargs):
     model = get_model(app,model)
     try:


### PR DESCRIPTION
See
http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html#using-the-shared-task-decorator

Using shared_task allows one to customize the celery configuration. It's recommended for third party apps. Without it the app will not work with anything but a default celery configuration.
